### PR TITLE
Handle unsupported URL schemes

### DIFF
--- a/internal/urlutil/urlutil.go
+++ b/internal/urlutil/urlutil.go
@@ -87,5 +87,9 @@ func CanonicalAddr(url *url.URL) string {
 	if port == "" {
 		port = portMap[url.Scheme]
 	}
-	return net.JoinHostPort(addr, port)
+	if port != "" {
+		return net.JoinHostPort(addr, port)
+	} else {
+		return addr
+	}
 }

--- a/internal/urlutil/urlutil_test.go
+++ b/internal/urlutil/urlutil_test.go
@@ -105,6 +105,16 @@ func TestCanonicalAddr(t *testing.T) {
 			Host:   "example.com:31337",
 			Path:   "/not/with/a/bang/but/a/whimper",
 		}: "example.com:31337",
+		{
+			Scheme: "myprotocol",
+			Host:   "example.com",
+			Path:   "/",
+		}: "example.com",
+		{
+			Scheme: "myprotocol",
+			Host:   "example.com:1234",
+			Path:   "/",
+		}: "example.com:1234",
 	}
 	for urlInput, expect := range tests {
 		if got := CanonicalAddr(urlInput); got != expect {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a test for custom protocol schemes, as suggested in original PR review.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
